### PR TITLE
Fix typo in product document

### DIFF
--- a/schemas/documents/product.tsx
+++ b/schemas/documents/product.tsx
@@ -102,7 +102,7 @@ export default defineType({
     },
     {
       name: 'priceAsc',
-      title: 'Title (Lowest first)',
+      title: 'Price (Lowest first)',
       by: [{field: 'store.priceRange.minVariantPrice', direction: 'asc'}],
     },
   ],


### PR DESCRIPTION
Fixed a typo in the sort order for prices (lowest first) in the product document schema.