### PR TITLE
Fix desk tool crash when adding images block

### DIFF
--- a/schemas/objects/module/images.tsx
+++ b/schemas/objects/module/images.tsx
@@ -23,7 +23,7 @@ export default defineField({
       type: 'boolean',
       description: 'Display single image at full width (on larger breakpoints)',
       initialValue: false,
-      hidden: ({parent}) => parent?.modules.length > 1,
+      hidden: ({parent}) => parent?.modules?.length > 1,
     }),
     // Vertical alignment
     defineField({
@@ -49,7 +49,7 @@ export default defineField({
           },
         ],
       },
-      hidden: ({parent}) => !parent?.modules || parent?.modules.length < 2,
+      hidden: ({parent}) => !parent?.modules || parent?.modules?.length < 2,
       validation: (Rule) => Rule.required(),
     }),
   ],


### PR DESCRIPTION
## This PR fixes the following behavior:
Desk Tool crashes when adding an **Images** block to the **Body** of a **Page**.

## Error message:
```
The desk tool crashed
Error: Cannot read properties of undefined (reading 'length')
TypeError: Cannot read properties of undefined (reading 'length')
    at hidden (http://localhost:3333/schemas/objects/module/images.tsx?t=1682078462446:29:28)
    at resolveConditionalProperty (http://localhost:3333/node_modules/.sanity/vite/deps/chunk-6RIAOIJY.js?v=5a78aaed:111714:10)
    at prepareFieldMember (http://localhost:3333/node_modules/.sanity/vite/deps/chunk-6RIAOIJY.js?v=5a78aaed:111874:21)
    at http://localhost:3333/node_modules/.sanity/vite/deps/chunk-6RIAOIJY.js?v=5a78aaed:111920:27
    at Array.flatMap (<anonymous>)
    at prepareObjectInputState (http://localhost:3333/node_modules/.sanity/vite/deps/chunk-6RIAOIJY.js?v=5a78aaed:111917:43)
    at prepareArrayOfObjectsMember (http://localhost:3333/node_modules/.sanity/vite/deps/chunk-6RIAOIJY.js?v=5a78aaed:112027:21)
    at http://localhost:3333/node_modules/.sanity/vite/deps/chunk-6RIAOIJY.js?v=5a78aaed:112007:50
    at Array.flatMap (<anonymous>)
    at prepareArrayOfObjectsInputState (http://localhost:3333/node_modules/.sanity/vite/deps/chunk-6RIAOIJY.js?v=5a78aaed:112007:25)
```
