### PR TITLE
updated Shopify URLs

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -26,6 +26,6 @@ export const PAGE_REFERENCES = [
 export const SANITY_API_VERSION = '2022-10-25'
 
 // Your Shopify store ID.
-// This is your unique store URL (e.g. 'https://admin.shopify.com/store/my-store-name/').
+// This is your unique store (e.g. 'my-store-name' in the complete URL of 'https://admin.shopify.com/store/my-store-name/').
 // Set this to enable helper links in document status banners and shortcut links on products and collections.
 export const SHOPIFY_STORE_ID = ''

--- a/constants.ts
+++ b/constants.ts
@@ -26,6 +26,6 @@ export const PAGE_REFERENCES = [
 export const SANITY_API_VERSION = '2022-10-25'
 
 // Your Shopify store ID.
-// This is your unique store URL (e.g. 'my-store-name.myshopify.com').
+// This is your unique store URL (e.g. 'https://admin.shopify.com/store/my-store-name/').
 // Set this to enable helper links in document status banners and shortcut links on products and collections.
 export const SHOPIFY_STORE_ID = ''

--- a/package-lock.json
+++ b/package-lock.json
@@ -13014,7 +13014,8 @@
     "@emotion/use-insertion-effect-with-fallbacks": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.0.tgz",
-      "integrity": "sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A=="
+      "integrity": "sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A==",
+      "requires": {}
     },
     "@emotion/utils": {
       "version": "1.2.0",
@@ -13245,7 +13246,8 @@
     "@hookform/resolvers": {
       "version": "2.0.0-beta.3",
       "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-2.0.0-beta.3.tgz",
-      "integrity": "sha512-sOP+IX7TglN34WbMVt8eRqWgnXAQcvFc4XUU6x3bIiIjTkjV5L3N7sBjff2Ln4QPTMYnmdXaZV2Yf5WxOiC5YQ=="
+      "integrity": "sha512-sOP+IX7TglN34WbMVt8eRqWgnXAQcvFc4XUU6x3bIiIjTkjV5L3N7sBjff2Ln4QPTMYnmdXaZV2Yf5WxOiC5YQ==",
+      "requires": {}
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -13278,7 +13280,8 @@
     "@icons/material": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
-      "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
+      "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==",
+      "requires": {}
     },
     "@jridgewell/gen-mapping": {
       "version": "0.3.3",
@@ -13707,7 +13710,8 @@
     "@sanity/icons": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-2.3.1.tgz",
-      "integrity": "sha512-DyUdjjWFIokrMewnK24Vvxpv2lKx5LrzUM3eEk0ZVwhS8+hWkFFN1Z7jhcwQnQ5NweejhzsZkT4JHUdffCAQaw=="
+      "integrity": "sha512-DyUdjjWFIokrMewnK24Vvxpv2lKx5LrzUM3eEk0ZVwhS8+hWkFFN1Z7jhcwQnQ5NweejhzsZkT4JHUdffCAQaw==",
+      "requires": {}
     },
     "@sanity/image-url": {
       "version": "1.0.2",
@@ -13776,14 +13780,16 @@
         "@sanity/icons": {
           "version": "1.3.10",
           "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-1.3.10.tgz",
-          "integrity": "sha512-5wVG/vIiGuGrSmq+Bl3PY7XDgQrGv0fyHdJI64FSulnr2wH3NMqZ6C59UFxnrZ93sr7kOt0zQFoNv2lkPBi0Cg=="
+          "integrity": "sha512-5wVG/vIiGuGrSmq+Bl3PY7XDgQrGv0fyHdJI64FSulnr2wH3NMqZ6C59UFxnrZ93sr7kOt0zQFoNv2lkPBi0Cg==",
+          "requires": {}
         }
       }
     },
     "@sanity/logos": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@sanity/logos/-/logos-2.1.2.tgz",
-      "integrity": "sha512-nxJUQQzEEG8EqjiOEswQQpBUuFc3iSxTVF9D9Memg/tlOChX76dStNHoa1RWuvSPu895aqJV+9zxijAa0kF9Vg=="
+      "integrity": "sha512-nxJUQQzEEG8EqjiOEswQQpBUuFc3iSxTVF9D9Memg/tlOChX76dStNHoa1RWuvSPu895aqJV+9zxijAa0kF9Vg==",
+      "requires": {}
     },
     "@sanity/mutator": {
       "version": "3.12.1",
@@ -14529,7 +14535,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "8.2.0",
@@ -15845,7 +15852,8 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
       "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-scope": {
       "version": "5.1.1",
@@ -17054,7 +17062,8 @@
     "jsdom-global": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/jsdom-global/-/jsdom-global-3.0.2.tgz",
-      "integrity": "sha512-t1KMcBkz/pT5JrvcJbpUR2u/w1kO9jXctaaGJ0vZDzwFnIvGWw9IDSRciT83kIs8Bnw4qpOl8bQK08V01YgMPg=="
+      "integrity": "sha512-t1KMcBkz/pT5JrvcJbpUR2u/w1kO9jXctaaGJ0vZDzwFnIvGWw9IDSRciT83kIs8Bnw4qpOl8bQK08V01YgMPg==",
+      "requires": {}
     },
     "jsesc": {
       "version": "2.5.2",
@@ -17568,7 +17577,8 @@
     "observable-callback": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/observable-callback/-/observable-callback-1.0.2.tgz",
-      "integrity": "sha512-Fb7qVUHqr8jl32NyJffTiqf76NObRvmzaSPgGtaAGH+Wfh45tiGWjrvUsNgEuCa86SUzGZZpoSN0hpGtldoSDg=="
+      "integrity": "sha512-Fb7qVUHqr8jl32NyJffTiqf76NObRvmzaSPgGtaAGH+Wfh45tiGWjrvUsNgEuCa86SUzGZZpoSN0hpGtldoSDg==",
+      "requires": {}
     },
     "once": {
       "version": "1.4.0",
@@ -18176,7 +18186,8 @@
     "react-hook-form": {
       "version": "6.15.8",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-6.15.8.tgz",
-      "integrity": "sha512-prq82ofMbnRyj5wqDe8hsTRcdR25jQ+B8KtCS7BLCzjFHAwNuCjRwzPuP4eYLsEBjEIeYd6try+pdLdw0kPkpg=="
+      "integrity": "sha512-prq82ofMbnRyj5wqDe8hsTRcdR25jQ+B8KtCS7BLCzjFHAwNuCjRwzPuP4eYLsEBjEIeYd6try+pdLdw0kPkpg==",
+      "requires": {}
     },
     "react-is": {
       "version": "18.2.0",
@@ -18419,7 +18430,8 @@
     "redux-thunk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
-      "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q=="
+      "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
+      "requires": {}
     },
     "refractor": {
       "version": "3.6.0",
@@ -18580,7 +18592,8 @@
     "rxjs-exhaustmap-with-trailing": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/rxjs-exhaustmap-with-trailing/-/rxjs-exhaustmap-with-trailing-2.1.1.tgz",
-      "integrity": "sha512-gK7nsKyPFsbjDeJ0NYTcZYGW5TbTFjT3iACa28Pwp3fIf9wT/JUR8vdlKYCjUOZKXYnXEk8eRZ4zcQyEURosIA=="
+      "integrity": "sha512-gK7nsKyPFsbjDeJ0NYTcZYGW5TbTFjT3iACa28Pwp3fIf9wT/JUR8vdlKYCjUOZKXYnXEk8eRZ4zcQyEURosIA==",
+      "requires": {}
     },
     "safe-buffer": {
       "version": "5.2.1",
@@ -19534,17 +19547,20 @@
     "use-device-pixel-ratio": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/use-device-pixel-ratio/-/use-device-pixel-ratio-1.1.2.tgz",
-      "integrity": "sha512-nFxV0HwLdRUt20kvIgqHYZe6PK/v4mU1X8/eLsT1ti5ck0l2ob0HDRziaJPx+YWzBo6dMm4cTac3mcyk68Gh+A=="
+      "integrity": "sha512-nFxV0HwLdRUt20kvIgqHYZe6PK/v4mU1X8/eLsT1ti5ck0l2ob0HDRziaJPx+YWzBo6dMm4cTac3mcyk68Gh+A==",
+      "requires": {}
     },
     "use-hot-module-reload": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/use-hot-module-reload/-/use-hot-module-reload-1.0.3.tgz",
-      "integrity": "sha512-Wk/sjFhOF+a6PkovJvDAT3c8yE1DluZsSB3L+gTS8pM4ht2yg/LqBj4YLwnYJSdPnFqGWvu93CMdso8bcKw36A=="
+      "integrity": "sha512-Wk/sjFhOF+a6PkovJvDAT3c8yE1DluZsSB3L+gTS8pM4ht2yg/LqBj4YLwnYJSdPnFqGWvu93CMdso8bcKw36A==",
+      "requires": {}
     },
     "use-isomorphic-layout-effect": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
-      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA=="
+      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
+      "requires": {}
     },
     "use-sidecar": {
       "version": "1.1.2",
@@ -19558,7 +19574,8 @@
     "use-sync-external-store": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
-      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA=="
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "requires": {}
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -19897,7 +19914,8 @@
     "ws": {
       "version": "8.13.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA=="
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "requires": {}
     },
     "xdg-basedir": {
       "version": "4.0.0",

--- a/utils/shopifyUrls.ts
+++ b/utils/shopifyUrls.ts
@@ -1,22 +1,24 @@
 import {SHOPIFY_STORE_ID} from '../constants'
 
+const storeUrl = `https://admin.shopify.com/store/${SHOPIFY_STORE_ID}`
+
 export const collectionUrl = (collectionId: number) => {
   if (!SHOPIFY_STORE_ID) {
     return null
   }
-  return `https://${SHOPIFY_STORE_ID}/admin/collections/${collectionId}`
+  return `${storeUrl}/collections/${collectionId}`
 }
 
 export const productUrl = (productId: number) => {
   if (!SHOPIFY_STORE_ID) {
     return null
   }
-  return `https://${SHOPIFY_STORE_ID}/admin/products/${productId}`
+  return `${storeUrl}/products/${productId}`
 }
 
 export const productVariantUrl = (productId: number, productVariantId: number) => {
   if (!SHOPIFY_STORE_ID) {
     return null
   }
-  return `https://${SHOPIFY_STORE_ID}/admin/products/${productId}/variants/${productVariantId}`
+  return `${storeUrl}/products/${productId}/variants/${productVariantId}`
 }


### PR DESCRIPTION
Currently, the Shopify URLs in the starter are:

```
`https://${SHOPIFY_STORE_ID}/admin/products/${productId}`
```

but there was an update not long ago changing the URLs to:

```
https://admin.shopify.com/store/${SHOPIFY_STORE_ID}/products/${productId}
```

and this pull request is to update those paths.
